### PR TITLE
update: list all gateway clients on refresh

### DIFF
--- a/app/src/main/java/com/example/sw0b_001/Models/GatewayClients/GatewayClientsCommunications.kt
+++ b/app/src/main/java/com/example/sw0b_001/Models/GatewayClients/GatewayClientsCommunications.kt
@@ -16,7 +16,7 @@ class GatewayClientsCommunications(context: Context) {
                                         val operator: String,
                                         val operator_code: String,
                                         val protocols: ArrayList<String>,
-                                        val last_published_date: String)
+                                        val last_published_date: Long)
 
     private val filename = "gateway_client_prefs"
     private val defaultKey = "DEFAULT_KEY"

--- a/app/src/main/java/com/example/sw0b_001/Settings/GatewayClientListingActivity.kt
+++ b/app/src/main/java/com/example/sw0b_001/Settings/GatewayClientListingActivity.kt
@@ -83,7 +83,12 @@ class GatewayClientListingActivity : AppCompactActivityCustomized() {
         linearProgressIndicator.visibility = View.VISIBLE
 
         gatewayClientsViewModel.loadRemote(applicationContext,
-                { refreshLayout.isRefreshing = false } ) {
+            {
+                runOnUiThread {
+                    refreshLayout.isRefreshing = false
+                    linearProgressIndicator.visibility = View.GONE
+                }
+            }) {
             runOnUiThread {
                 refreshLayout.isRefreshing = false
                 linearProgressIndicator.visibility = View.GONE


### PR DESCRIPTION
The refreshing issue came from an error with the deserializing of the json response. The `last_published_date` fields in the response was a number however `GatewayClientJsonPayload` was expecting a string. Therefore the `fetchAndPopulateWithDefault` function was not properly executing

Also after the refresh was being made the the loading indicator kept displaying because it was stuck in the wrong thread.
