### PR TITLE
Add functionality to select contact from contact list as a gateway client

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
-    <uses-permission android:name="android.permission.READ_CONTACTS" />
 
     <queries>
         <intent>

--- a/app/src/main/java/com/example/sw0b_001/Models/GatewayClients/GatewayClientAddModalFragment.kt
+++ b/app/src/main/java/com/example/sw0b_001/Models/GatewayClients/GatewayClientAddModalFragment.kt
@@ -7,11 +7,9 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
 import android.provider.ContactsContract
-import android.util.Log
 import android.view.View
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.example.sw0b_001.Database.Datastore
 import com.example.sw0b_001.R
@@ -36,7 +34,7 @@ class GatewayClientAddModalFragment :
             } else {
                 Toast.makeText(
                     requireContext(),
-                    "Permission to read contacts denied",
+                    getString(R.string.read_contacts_permission_denied),
                     Toast.LENGTH_SHORT
                 ).show()
             }
@@ -53,7 +51,6 @@ class GatewayClientAddModalFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        Log.d("GatewayClientAddModalFragment", "View: $view")
         val bottomSheet = view.findViewById<View>(R.id.gateway_client_add_modal)
 
         bottomSheetBehavior = BottomSheetBehavior.from(bottomSheet)
@@ -101,10 +98,7 @@ class GatewayClientAddModalFragment :
                 selectContact()
             }
 
-            ActivityCompat.shouldShowRequestPermissionRationale(
-                requireActivity(),
-                Manifest.permission.READ_CONTACTS
-            ) -> {
+            shouldShowRequestPermissionRationale(Manifest.permission.READ_CONTACTS) -> {
                 Toast.makeText(
                     requireContext(),
                     getString(R.string.request_contact_permission),
@@ -112,9 +106,16 @@ class GatewayClientAddModalFragment :
                 ).show()
                 requestPermissionLauncher.launch(Manifest.permission.READ_CONTACTS)
             }
-
             else -> {
-                requestPermissionLauncher.launch(Manifest.permission.READ_CONTACTS)
+                Toast.makeText(
+                    requireContext(),
+                    getString(R.string.grant_contact_permission_from_settings),
+                    Toast.LENGTH_SHORT
+                ).show()
+                val intent = Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                val uri: Uri = Uri.fromParts("package", requireActivity().packageName, null)
+                intent.data = uri
+                startActivity(intent)
             }
         }
     }

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -153,7 +153,5 @@
     <string name="revoke_platforms">ابطال پلتفرم ها</string>
     <string name="validate_with_phone_number">با شماره تلفن تایید کنید</string>
     <string name="the_code_can_be_automatically_detected_in_some_cases">کد را می توان به طور خودکار در برخی موارد شناسایی کرد</string>
-    <string name="request_contact_permission">لطفا اجازه انتخاب مخاطب را بدهید</string>
-    <string name="read_contacts_permission_denied">مجوز خواندن مخاطبین رد شد</string>
-    <string name="grant_contact_permission_from_settings">لطفا اجازه دسترسی به مخاطبین را از تنظیمات برنامه اعطا کنید</string>
+
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -154,4 +154,6 @@
     <string name="validate_with_phone_number">با شماره تلفن تایید کنید</string>
     <string name="the_code_can_be_automatically_detected_in_some_cases">کد را می توان به طور خودکار در برخی موارد شناسایی کرد</string>
     <string name="request_contact_permission">لطفا اجازه انتخاب مخاطب را بدهید</string>
+    <string name="read_contacts_permission_denied">مجوز خواندن مخاطبین رد شد</string>
+    <string name="grant_contact_permission_from_settings">لطفا اجازه دسترسی به مخاطبین را از تنظیمات برنامه اعطا کنید</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -154,4 +154,6 @@
     <string name="selected_gateway_client_text">Client de passerelle SMS sélectionné</string>
     <string name="the_code_can_be_automatically_detected_in_some_cases">Le code peut être détecté automatiquement dans certains cas</string>
     <string name="request_contact_permission">Veuillez accorder l\u00A0autorisation de s\u00E9lectionner un contact</string>
+    <string name="read_contacts_permission_denied">Autorisation de lire les contacts refusée</string>
+    <string name="grant_contact_permission_from_settings">Veuillez accorder la permission d\'accès aux contacts depuis les paramètres de l\'application</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -153,7 +153,5 @@
     <string name="validate_with_phone_number">Valider avec le numéro de téléphone</string>
     <string name="selected_gateway_client_text">Client de passerelle SMS sélectionné</string>
     <string name="the_code_can_be_automatically_detected_in_some_cases">Le code peut être détecté automatiquement dans certains cas</string>
-    <string name="request_contact_permission">Veuillez accorder l\u00A0autorisation de s\u00E9lectionner un contact</string>
-    <string name="read_contacts_permission_denied">Autorisation de lire les contacts refusée</string>
-    <string name="grant_contact_permission_from_settings">Veuillez accorder la permission d\'accès aux contacts depuis les paramètres de l\'application</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -262,8 +262,5 @@
     <string name="revoke_platforms">Revoke Platforms</string>
     <string name="validate_with_phone_number">Validate with phone number</string>
     <string name="the_code_can_be_automatically_detected_in_some_cases">The code can be automatically detected in some cases</string>
-    <string name="request_contact_permission">Please grant permission to select a contact</string>
-    <string name="read_contacts_permission_denied">Permission to read contacts denied</string>
-    <string name="grant_contact_permission_from_settings">Please grant contact access permission from app settings</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -263,5 +263,7 @@
     <string name="validate_with_phone_number">Validate with phone number</string>
     <string name="the_code_can_be_automatically_detected_in_some_cases">The code can be automatically detected in some cases</string>
     <string name="request_contact_permission">Please grant permission to select a contact</string>
+    <string name="read_contacts_permission_denied">Permission to read contacts denied</string>
+    <string name="grant_contact_permission_from_settings">Please grant contact access permission from app settings</string>
 
 </resources>


### PR DESCRIPTION
This tackles #119 

Users can now add a contact as a gateway client directly from their contact list but first they have to grant permission.